### PR TITLE
Fix depsetting

### DIFF
--- a/chapter7/test_opencv/CMakeLists.txt
+++ b/chapter7/test_opencv/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(OpenCV REQUIRED)
 
 catkin_package(
-  INCLUDE_DIRS include
+  INCLUDE_DIRS 
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS cv_bridge image_transport roscpp rospy sensor_msgs std_msgs
   DEPENDS system_lib

--- a/chapter8/cloud_excercise/package.xml
+++ b/chapter8/cloud_excercise/package.xml
@@ -6,7 +6,7 @@
 
   <maintainer email="p595201m@mail.kyutech.jp">MoriKen</maintainer>
 
-  <license>TODO</license>
+  <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>pcl_conversions</depend>

--- a/chapter9/joy_control/package.xml
+++ b/chapter9/joy_control/package.xml
@@ -5,9 +5,8 @@
   <description>The joy_control package</description>
 
   <maintainer email="p595201m@mail.kyutech.jp">Masaru Morita</maintainer>
-  <license>TODO</license>
+  <license>BSD</license>
 
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>joy</exec_depend>
-  <exec_depend>joy_twist</exec_depend>
 </package>


### PR DESCRIPTION
まっさらな環境で試すといろいろ怒られたので、下記を修正。

- `joy_twist` は公式パッケージではないので`rosdep`で怒られる。
- `test_opencv`内のincludeディレクトリはソースコードの簡略化のため削除。