### PR TITLE
Fix xacro

### DIFF
--- a/chapter6/fourth_robot_description/launch/fourth_robot_description.launch
+++ b/chapter6/fourth_robot_description/launch/fourth_robot_description.launch
@@ -4,7 +4,7 @@
   <arg name="gui" default="true" />
 
   <!-- prameters -->
-  <param name="robot_description" command="$(find xacro)/xacro.py '$(arg model)'"/>
+  <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model)"/>
   <param name="use_gui" value="$(arg gui)"/>
 
   <!-- nodes -->

--- a/chapter6/fourth_robot_description/robots/fourth_robot.urdf.xacro
+++ b/chapter6/fourth_robot_description/robots/fourth_robot.urdf.xacro
@@ -78,7 +78,7 @@
   <!-- Wheel -->
   <xacro:wheel_gazebo_v0 prefix="right"/>
   <xacro:wheel_gazebo_v0 prefix="left"/>
-  <xacro:wheel_gazebo_control_v0 rate="25"/>
+  <!--xacro:wheel_gazebo_control_v0 rate="25"/-->
 
   <!-- LRF -->
   <xacro:lrf_gazebo_v0 prefix="front"

--- a/chapter6/fourth_robot_description/urdf/base/base.urdf.xacro
+++ b/chapter6/fourth_robot_description/urdf/base/base.urdf.xacro
@@ -5,7 +5,7 @@
   
   <xacro:macro name="base_v0" params="parent *joint_origin">
 	<joint name="base_link_joint" type="fixed">
-	  <insert_block name="joint_origin"/>
+	  <xacro:insert_block name="joint_origin"/>
 	  <parent link="${parent}"/>
 	  <child link="base_link"/>
 	</joint>

--- a/chapter6/fourth_robot_description/urdf/common.xacro
+++ b/chapter6/fourth_robot_description/urdf/common.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-  <property name="M_PI" value="3.14159274"/>
+  <xacro:property name="M_PI" value="3.14159274"/>
 
   <xacro:macro name="cylinder_inertial" params="mass radius length">
 	<mass value="${mass}"/>

--- a/chapter6/fourth_robot_description/urdf/sensors/gim30/gim30.urdf.xacro
+++ b/chapter6/fourth_robot_description/urdf/sensors/gim30/gim30.urdf.xacro
@@ -5,7 +5,7 @@
   
   <xacro:macro name="gim30_v0" params="parent *joint_origin">
 	<joint name="gim30_joint" type="fixed">
-      <insert_block name="joint_origin" />
+      <xacro:insert_block name="joint_origin" />
       <parent link="${parent}"/>
       <child link="gim30_link"/>
 	</joint>

--- a/chapter6/fourth_robot_description/urdf/sensors/gps/gps.urdf.xacro
+++ b/chapter6/fourth_robot_description/urdf/sensors/gps/gps.urdf.xacro
@@ -5,7 +5,7 @@
 
   <xacro:macro name="gps_v0" params="parent *joint_origin">
 	<joint name="gps_joint" type="fixed">
-	  <insert_block name="joint_origin"/>
+	  <xacro:insert_block name="joint_origin"/>
 	  <parent link="${parent}"/>
 	  <child link="gps_link"/>
 	</joint>

--- a/chapter6/fourth_robot_description/urdf/sensors/lrf/lrf.urdf.xacro
+++ b/chapter6/fourth_robot_description/urdf/sensors/lrf/lrf.urdf.xacro
@@ -6,7 +6,7 @@
 
   <xacro:macro name="lrf_v0" params="prefix parent *joint_origin">
 	<joint name="${prefix}_lrf_joint" type="fixed">
-	  <insert_block name="joint_origin"/>
+	  <xacro:insert_block name="joint_origin"/>
 	  <parent link="${parent}"/>
 	  <child link="${prefix}_lrf_link"/>
 	</joint>

--- a/chapter6/fourth_robot_description/urdf/wheel/wheel.urdf.xacro
+++ b/chapter6/fourth_robot_description/urdf/wheel/wheel.urdf.xacro
@@ -5,16 +5,16 @@
   <xacro:include filename="$(find fourth_robot_description)/urdf/wheel/wheel.transmission.xacro"/>
   <xacro:include filename="$(find fourth_robot_description)/urdf/wheel/wheel.gazebo.xacro"/>
 
-  <property name="wheel_radius" value="0.20316"/>
-  <property name="wheel_length" value="0.032"/>
-  <property name="wheel_mass" value="2.0"/>
+  <xacro:property name="wheel_radius" value="0.20316"/>
+  <xacro:property name="wheel_length" value="0.032"/>
+  <xacro:property name="wheel_mass" value="2.0"/>
   
   <xacro:macro name="wheel_v0" params="prefix parent *joint_origin *joint_axis">
 	<joint name="${prefix}_wheel_joint" type="continuous">
-	  <insert_block name="joint_origin"/>
+	  <xacro:insert_block name="joint_origin"/>
 	  <parent link="${parent}"/>
 	  <child link="${prefix}_wheel_link"/>
-	  <insert_block name="joint_axis"/>
+	  <xacro:insert_block name="joint_axis"/>
 	</joint>
 
 	<link name="${prefix}_wheel_link">

--- a/chapter9/fourth_robot_2dnav/launch/gmapping.launch
+++ b/chapter9/fourth_robot_2dnav/launch/gmapping.launch
@@ -8,5 +8,5 @@
   <node name="playbag" pkg="rosbag" type="play"
 		args="--clock $(arg bag_filename)" />
   
-  <node name="rviz" pkg="rviz" type="rviz" required="true" args="-d $(find fourth_robot_2dnav)/rviz/move_base.rviz" />
+  <node name="rviz" pkg="rviz" type="rviz" required="true" args="-d $(find fourth_robot_2dnav)/rviz/gmapping.rviz" />
 </launch>

--- a/chapter9/fourth_robot_2dnav/rviz/gmapping.rviz
+++ b/chapter9/fourth_robot_2dnav/rviz/gmapping.rviz
@@ -284,36 +284,6 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Class: jsk_rviz_plugin/TabletViewController
-      Control Mode: Orbit
-      Distance: 33.2152
-      Enable Stereo Rendering:
-        Stereo Eye Separation: 0.06
-        Stereo Focal Distance: 1
-        Swap Stereo Eyes: false
-        Value: false
-      Eye:
-        X: -21.2605
-        Y: 0.728007
-        Z: 20.2649
-      Focus:
-        X: 1.47552
-        Y: -0.0459718
-        Z: -3.9368
-      Maintain Vertical Axis: true
-      Mouse Enabled: true
-      Name: Current View
-      Near Clip Distance: 0.01
-      Placement Mouse Point: /rviz/current_mouse_point
-      Placement Publish Topic: /rviz/current_camera_placement
-      Placement Topic: /rviz/camera_placement
-      Target Frame: base_footprint
-      Transition Time: 0.5
-      Up:
-        X: 0
-        Y: 0
-        Z: 1
-      Value: TabletViewController (jsk_rviz_plugin)
     Saved: ~
 Window Geometry:
   Displays:

--- a/chapter9/fourth_robot_2dnav/rviz/navigation.rviz
+++ b/chapter9/fourth_robot_2dnav/rviz/navigation.rviz
@@ -370,39 +370,6 @@ Visualization Manager:
       Single click: true
       Topic: /clicked_point
   Value: true
-  Views:
-    Current:
-      Class: jsk_rviz_plugin/TabletViewController
-      Control Mode: Orbit
-      Distance: 34.6542
-      Enable Stereo Rendering:
-        Stereo Eye Separation: 0.06
-        Stereo Focal Distance: 1
-        Swap Stereo Eyes: false
-        Value: false
-      Eye:
-        X: -19.4525
-        Y: -1.9377
-        Z: 17.7594
-      Focus:
-        X: 7.65311
-        Y: 1.22177
-        Z: -3.59978
-      Maintain Vertical Axis: true
-      Mouse Enabled: true
-      Name: Current View
-      Near Clip Distance: 0.01
-      Placement Mouse Point: /rviz/current_mouse_point
-      Placement Publish Topic: /rviz/current_camera_placement
-      Placement Topic: /rviz/camera_placement
-      Target Frame: map
-      Transition Time: 0.5
-      Up:
-        X: 0
-        Y: 0
-        Z: 1
-      Value: TabletViewController (jsk_rviz_plugin)
-    Saved: ~
 Window Geometry:
   Displays:
     collapsed: true


### PR DESCRIPTION
6章と9章の内容で，修正しないとkineticで動かないというこれまた大変な状況だったので，修正（この段階で見つけられて良かった…。本当にクレームものです…。）。

- xacro フォーマットをkinetic用に修正
- launch 内でxacro をcallするフォーマットをkinetic用に修正
- rviz ファイル内に記述されたjsk_visualizationパッケージを削除（余計なものは排除したい）
- gmapping時にcallするrvizファイル名を修正

後ほど、本文のどこをどう修正すればよいか、ご連絡します。

kinetic問題、きちんと確認しないと、深いかもしれません。