### PR TITLE
[Add] add ten_times_publisher for simple_server2

### DIFF
--- a/chapter10/actionlib_sample/script/ten_times_publisher.py
+++ b/chapter10/actionlib_sample/script/ten_times_publisher.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import rospy
+from std_msgs.msg import Float32
+import random
+
+def ten_times_publish():
+  pub = rospy.Publisher('number', Float32, queue_size=10)
+  r = rospy.Rate(5)
+
+  # invoke
+  number = 1.0
+  pub.publish(number)
+  rospy.loginfo('published number[%d]: %f'%(0,number))
+  r.sleep()
+
+  for i in range(10):
+    number = random.random()
+    pub.publish(number)
+    rospy.loginfo('published number[%d]: %f'%(i+1,number))
+    r.sleep()
+
+if __name__ == '__main__':
+  rospy.init_node('ten_times_publisher')
+  ten_times_publish()
+  rospy.spin()


### PR DESCRIPTION
10章のactionlibのサンプル用の補足プログラム。Travisが通ったらマージします。

simple_server2は、simple_clientに加えて、トピックを10回パブリッシュする人を別に用意しないと動かないのですが、そのコードのサンプルがないので、しれっと入れておきます。

このコードがないと、コマンドラインかGUIのパブリッシャーから5秒以内に10回連続で異なる値をパブリッシュするという、よくわからない芸当が必要になるので笑。どっちにしてもキツイです。

本文に載せるとまたページ数が増えるので、そこは割愛します。熱心な読者であれば、この点に気が付き、サンプルコードのフォルダを見てくれるかなーと期待して。